### PR TITLE
Change XHR request URL to base CP URL

### DIFF
--- a/src/web/assets/searchit/build/js/ElementFilters.js
+++ b/src/web/assets/searchit/build/js/ElementFilters.js
@@ -120,7 +120,7 @@ var ElementFilters = (function() {
 			}
 
 			var xhr = new XMLHttpRequest();
-			xhr.open("POST", "/", true);
+			xhr.open("POST", Craft.baseCpUrl, true);
 			xhr.setRequestHeader("X-Requested-With", "XMLHttpRequest");
 			xhr.setRequestHeader("Accept", "application/json");
 


### PR DESCRIPTION
Front-end action URL requests are treated differently than control panel action URL requests. [Snaptcha](https://putyourlightson.com/plugins/snaptcha), for example, blocks all POST requests to the front-end that do not contain a validation field value. CP requests however are not validated because the user is assumed to anyway be authenticated.

Since XHR calls to `searchit/element-filters/get` are valid for the CP only, this pull request changes the XHR request from the front-end URL to the base CP URL for more consistent behaviour. I hope you'll consider it :)